### PR TITLE
Add function for reverse engineering savename (#65)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/build
 docs/data
 Manifest.toml
 test/testdir
+src/update*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 0.6.0
 * **[BREAKING]** Reworked the way the functions `projectdir` and derivatives work (#47, #64, #66). Now `projectdir(args...)` uses `joinpath` to connect arguments. None of the functions like `projectdir` and derivatives now end in `/` as well, to ensure more stability and motivate users to use `joinpath` or the new functionality of `projectdir(args...)` instead of using string multiplication `*`.
+* New function `parse_savename` that attempts to reverse engineer the result of `savename`.
+
 # 0.5.1
 * Improvements to `.gitignore` (#55 , #54)
 # 0.5.0

--- a/docs/src/name.md
+++ b/docs/src/name.md
@@ -38,3 +38,8 @@ DrWatson.default_expand
 
 See [Real World Examples](@ref) for an example of customizing `savename`.
 Specifically, have a look at [`savename` and nested containers](@ref) for a way to
+
+## Reverse-engineering `savename`
+```@docs
+parse_savename
+```

--- a/src/DrWatson.jl
+++ b/src/DrWatson.jl
@@ -43,6 +43,8 @@ This will likely break usage of e.g. `datadir` that used `*`, like it was
 suggested in the old (unhealthy) documentation. We are very sorry
 for this inconvenience!
 
+[NEW] New funtion `parse_savename` that reverse-engineers the output
+of `savename`!
 \n
 """; color = :light_magenta)
 touch(joinpath(@__DIR__, update_name))

--- a/test/naming_tests.jl
+++ b/test/naming_tests.jl
@@ -58,3 +58,81 @@ s = savename(e; allowedtypes = (Any,), expand = ["c"])
 @test ')' ∈ s
 @test occursin("a=3", s)
 @test occursin("b=4", s)
+
+# Tests for parse_savename
+
+function test_convert(prefix::AbstractString,c;kwargs...)
+    name = savename(prefix,c;kwargs...)
+    _prefix, _b, _suffix = DrWatson.parse_savename(name)
+    dicts_equal(_b,c) && _prefix == prefix && _suffix == ""
+end
+
+function test_convert(c,suffix::AbstractString;kwargs...)
+    name = savename(c,suffix;kwargs...)
+    _prefix, _b, _suffix = DrWatson.parse_savename(name)
+    dicts_equal(_b,c) && _suffix == suffix && _prefix == ""
+end
+
+function test_convert(prefix::AbstractString,c,suffix::AbstractString;kwargs...)
+    name = savename(prefix,c,suffix;kwargs...)
+    _prefix, _b, _suffix = DrWatson.parse_savename(name)
+    dicts_equal(_b,c) && _suffix == suffix && _prefix == prefix
+end
+
+function test_convert(c;kwargs...)
+    name = savename(c;kwargs...)
+    _prefix, _b, _suffix = DrWatson.parse_savename(name)
+    dicts_equal(_b,c) && _prefix == "" && _suffix == ""
+end
+
+function dicts_equal(a,b)
+    kA,kB = keys(a), keys(b)
+    kA != kB && return false
+    for k ∈ kA
+        a[k] != b[k] && return false
+    end
+    return true
+end
+
+
+@test test_convert(
+    Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "double"),
+    digits=4)
+@test test_convert("prefix",
+                   Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "double"),
+                   digits=4)
+@test test_convert(
+    Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "double"),
+    "suffix",
+    digits=4)
+@test test_convert("prefix",
+                   Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mode" => "double"),
+                   "suffix",
+                   digits=4)
+@test test_convert("prefix",
+                   Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "variable_with_underscore" => "double"),
+                   "suffix",
+                   digits=4)
+@test test_convert(joinpath("a=10_mode=double","prefix"),
+                   Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "variable_with_underscore" => "double"),
+                   "suffix",
+                   digits=4)
+@test test_convert(Dict("c" => 0.1534, "u" => 5.1),
+                   digits=4)
+@test test_convert(Dict("never" => "gonna", "give" => "you", "up" => "!"))
+@test test_convert(Dict("c" => 0.1534),
+                   digits=4)
+
+b = Dict("c" => 0.1534, "u" => 5.1, "r"=>101, "mo_de" => "double")
+name = savename("prefix",b,connector="_",digits=4)
+_prefix, _b, _suffix = DrWatson.parse_savename(name,connector="_")
+@test dicts_equal(_b,b) && _prefix == "prefix" && _suffix == ""
+
+_prefix, _b, _suffix = DrWatson.parse_savename(joinpath("some_random_path_a=10.0","prefix")*"_a=10_just_a_string=I'm not allowed to use underscores here_my_value=10.1.suffix_with_underscore-but-don't-use-dots")
+@test _prefix == joinpath("some_random_path_a=10.0","prefix")
+@test _suffix == "suffix_with_underscore-but-don't-use-dots"
+@test _b["a"] == 10.0
+@test _b["just_a_string"] == "I'm not allowed to use underscores here"
+@test _b["my_value"] == 10.1
+
+@test_throws ErrorException DrWatson.parse_savename("a=10",connector="__")


### PR DESCRIPTION
* Add function for reverse engineering savename

* Switch to dirname and basename instead of splitpath

* Remove isnothing for compat. with julia 1.0

* Fix unit tests

* Remove leftover kw def from docstring

* Change parsing scheme to underscore in key instead of value

* Add check for limiting connector to a single character

* Switch to joinpath in test to support windows

* documentation related updates

* ops, update tests as well